### PR TITLE
chore: fix failed to resolve entry

### DIFF
--- a/playground/package.json
+++ b/playground/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@storyblok/playground",
   "version": "0.0.1",
+  "type": "module",
   "scripts": {
     "demo": "vite"
   },


### PR DESCRIPTION
It fixes the error when you launch `npm run demo`: [ERROR] [plugin externalize-deps].

✘ [ERROR] [plugin externalize-deps] Failed to resolve entry for package "@sveltejs/vite-plugin-svelte". The package may have incorrect main/module/exports specified in its package.json: No known conditions for "." specifier in "@sveltejs/vite-plugin-svelte" package